### PR TITLE
200ms speed up

### DIFF
--- a/meme_check_bypass/utilities/utilities.cpp
+++ b/meme_check_bypass/utilities/utilities.cpp
@@ -1,6 +1,6 @@
 #include "utilities.hpp"
 
-std::vector<std::uintptr_t> mem_scanner::scan_pattern(std::string_view pattern, std::string_view mask, std::pair<std::uint32_t, std::uint32_t> scan_bounds)
+std::vector<std::uintptr_t> mem_scanner::scan_pattern(std::string_view pattern, std::string_view mask, std::pair<std::uint32_t, std::uint32_t> scan_bounds, int max_size)
 {
 	std::vector<std::uintptr_t> results_list = {};
 	auto& [start_address, end_address] = scan_bounds;
@@ -19,7 +19,10 @@ std::vector<std::uintptr_t> mem_scanner::scan_pattern(std::string_view pattern, 
 		}
 
 		if (matching)
+		{
 			results_list.emplace_back(start_address);
+			if (results_list.size() == max_size) break;
+		}
 
 		++start_address;
 	}


### PR DESCRIPTION
when scanning pattern and using [0] only first element is required so we break after size 1
when checking if matches.size() == 1 we need only 2 matches max cus 0 (not found) < 1 (size we need) < 2 (more size than needed)
when doing for loops we use 0 cus it wont break since we check the size after inserting smth to matches
and when just scanning pattern like that if (scan_pattern() && scan_pattern() && scan_pattern()) we break after size 1 cus 0 == false and >=1 is true